### PR TITLE
Add Windows Build Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,12 +51,20 @@ docker-compose up --build -d
    ```
 
 2. Run the build script (creates virtual environment and builds the package):
+
+   **On Linux/macOS:**
    ```bash
    # Make the script executable
    chmod +x scripts/build.sh
 
    # Run the build script
    ./scripts/build.sh
+   ```
+
+   **On Windows:**
+   ```cmd
+   # Run the build script
+   scripts\build.bat
    ```
 
    The build script will:
@@ -67,9 +75,20 @@ docker-compose up --build -d
    - Provide installation instructions
 
 3. Install the package:
+
+   First, activate the virtual environment:
+
+   **On Linux/macOS:**
    ```bash
-   # Activate the virtual environment created by build.sh
-   source venv/bin/activate  # On Windows: venv\Scripts\activate
+   source venv/bin/activate
+   ```
+
+   **On Windows:**
+   ```cmd
+   venv\Scripts\activate
+   ```
+
+   Then install the package:
 
    # For development (editable install)
    pip install -e .

--- a/scripts/build.bat
+++ b/scripts/build.bat
@@ -1,0 +1,84 @@
+@echo off
+setlocal enabledelayedexpansion
+
+:: Check if Python is available
+where python >nul 2>&1
+if %ERRORLEVEL% neq 0 (
+    echo Error: Python is not found in PATH
+    exit /b 1
+)
+
+:: Check Python version
+for /f "tokens=2 delims=." %%I in ('python -c "import sys; print(sys.version.split()[0])"') do set PYTHON_VERSION=%%I
+python -c "import sys; v=sys.version_info; exit(0 if v.major>=3 and v.minor>=9 else 1)"
+if %ERRORLEVEL% neq 0 (
+    echo Error: Python 3.9 or higher is required
+    python --version
+    exit /b 1
+)
+
+echo Checking system dependencies...
+echo Python version:
+python --version
+
+:: Create and activate virtual environment
+echo Creating virtual environment...
+if exist venv (
+    echo Removing existing virtual environment...
+    rmdir /s /q venv
+)
+python -m venv venv
+
+:: Activate virtual environment
+call venv\Scripts\activate.bat
+
+:: Upgrade pip and install build dependencies
+echo Installing build dependencies...
+python -m pip install --upgrade pip
+pip install build wheel setuptools_scm
+
+:: Clean previous builds
+echo Cleaning previous builds...
+if exist dist rmdir /s /q dist
+if exist build rmdir /s /q build
+if exist *.egg-info rmdir /s /q *.egg-info
+
+:: Build the package
+echo Building package...
+python -m build
+
+:: Verify the build
+if exist dist (
+    echo Build successful! The following files were created:
+    dir /b dist
+) else (
+    echo Error: Build failed - no files were created in dist/
+    exit /b 1
+)
+
+:: Run tests if pytest is available
+where pytest >nul 2>&1
+if %ERRORLEVEL% equ 0 (
+    echo Running tests...
+    pytest
+)
+
+echo.
+echo Build complete! To install the package:
+echo.
+echo 1. Install from wheel file:
+echo    pip install dist\openhands_event_tracker-*.whl
+echo.
+echo 2. Or install in development mode:
+echo    pip install -e .
+echo.
+echo To run the application:
+echo 1. Start Kafka ^(if not using Docker^):
+echo    docker-compose up -d kafka
+echo.
+echo 2. Run the application:
+echo    event-tracker
+echo.
+
+:: Deactivate virtual environment
+deactivate

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -10,9 +10,9 @@ command_exists() {
 
 # Function to check Python version
 check_python_version() {
-    python_version=$(python3 -c 'import sys; print(f"{sys.version_info.major}.{sys.version_info.minor}")')
-    if (( $(echo "$python_version < 3.9" | bc -l) )); then
-        echo "Error: Python 3.9 or higher is required (found $python_version)"
+    python_version=$(python3 -c 'import sys; v=sys.version_info; print(f"{v.major}{v.minor}")')
+    if [ "$python_version" -lt 39 ]; then
+        echo "Error: Python 3.9 or higher is required (found $(python3 --version))"
         exit 1
     fi
 }


### PR DESCRIPTION
This PR adds Windows build support to the project.

### Changes

- Add build.bat script for Windows builds
- Fix Python version check in build scripts
- Update documentation with Windows-specific instructions

### Features

- Windows build script with equivalent functionality to build.sh
- Proper Python version detection on Windows
- Clear Windows-specific installation and usage instructions

### Testing

To test on Windows:

```cmd
# Build the package
scripts\build.bat

# Install the package
venv\Scripts\activate
pip install -e .

# Run with Docker
docker-compose up -d
```